### PR TITLE
fix!: make page param patch for request

### DIFF
--- a/src/core/types/DataSource.ts
+++ b/src/core/types/DataSource.ts
@@ -24,7 +24,7 @@ export interface DataSource<
         fetchContext: TFetchContext,
         request: TRequest,
     ) => Promise<TResponse> | TResponse;
-    tags?: (params: ActualParams<this, TParams, TRequest>) => DataSourceTag[];
+    tags?: (params: ActualParams<TParams, TRequest>) => DataSourceTag[];
 
     transformParams?: (params: TParams) => TRequest;
     transformResponse?: (response: TResponse) => TData;
@@ -65,7 +65,7 @@ export type DataSourceParams<TDataSource> =
         infer _TState,
         infer _TFetchContext
     >
-        ? ActualParams<TDataSource, TParams, TRequest>
+        ? ActualParams<TParams, TRequest>
         : never;
 
 export type DataSourceRequest<TDataSource> =
@@ -173,12 +173,8 @@ export type DataSourceFetchContext<TDataSource> =
         ? TFetchContext
         : never;
 
-export type ActualParams<TDataSource extends AnyDataSource, TParams, TRequest> =
-    | (unknown extends TParams
-          ? TRequest
-          : undefined extends TDataSource['transformParams']
-            ? TRequest
-            : TParams)
+export type ActualParams<TParams, TRequest> =
+    | (unknown extends TParams ? TRequest : TParams)
     | typeof idle;
 
 export type ActualData<TData, TResponse> = unknown extends TData ? TResponse : TData;

--- a/src/react-query/impl/infinite/types.ts
+++ b/src/react-query/impl/infinite/types.ts
@@ -17,11 +17,11 @@ export type InfiniteQueryDataSource<TParams, TRequest, TResponse, TData, TError>
     TError,
     InfiniteQueryObserverOptions<TResponse, TError, ActualData<TData, TResponse>, TResponse>,
     ResultWrapper<InfiniteQueryObserverResult<ActualData<TData, TResponse>, TError>>,
-    QueryFunctionContext<DataSourceKey, TParams>
+    QueryFunctionContext<DataSourceKey, Partial<TRequest> | undefined>
 > & {
     type: 'infinite';
-    next: (lastPage: TResponse, allPages: TResponse[]) => Partial<TParams> | undefined;
-    prev?: (firstPage: TResponse, allPages: TResponse[]) => Partial<TParams> | undefined;
+    next: (lastPage: TResponse, allPages: TResponse[]) => Partial<TRequest> | undefined;
+    prev?: (firstPage: TResponse, allPages: TResponse[]) => Partial<TRequest> | undefined;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
BREAKING CHANGE: `next` and `prev` are `Partial<TRequest> | undefined` instead of `Partial<TResponse> | undefined`, DataSource no longer supports in `ActualParams` type
Release-As: 0.2.1