### PR TITLE
feat(withCatch): avoid never[] widening union when success type is an array

### DIFF
--- a/src/core/utils/withCatch.ts
+++ b/src/core/utils/withCatch.ts
@@ -26,8 +26,19 @@
 export function withCatch<TArgs extends unknown[], TFetchReturnType, TCatchReturnType>(
     fetchFn: (...args: TArgs) => Promise<TFetchReturnType>,
     onCatchFn: (reason: unknown) => TCatchReturnType,
-): (...args: TArgs) => Promise<TFetchReturnType | TCatchReturnType> {
+): (...args: TArgs) => Promise<WithCatchMergedReturn<TFetchReturnType, TCatchReturnType>> {
     return (...args) => {
-        return fetchFn(...args).catch(onCatchFn) as Promise<TFetchReturnType | TCatchReturnType>;
+        return fetchFn(...args).catch(onCatchFn) as Promise<
+            WithCatchMergedReturn<TFetchReturnType, TCatchReturnType>
+        >;
     };
 }
+
+/** If success is array-typed, an inferred `() => []` handler (`never[]`) is merged into the success type. */
+type WithCatchMergedReturn<TSuccess, TCatch> = [TCatch] extends [never]
+    ? TSuccess
+    : [TSuccess] extends [readonly unknown[]]
+      ? TCatch extends readonly never[]
+          ? TSuccess
+          : TSuccess | TCatch
+      : TSuccess | TCatch;


### PR DESCRIPTION
Union successful fetch result with the catch handler return type, with a narrowing when the success type is array-like and the handler is inferred as returning `never[]` (e.g. `() => []`). Use tuple-wrapped conditionals so unions in the success type are not distributed incorrectly.

```ts
/*
 * Before, the return type was () => Promise<number[] | never[]>, after it is () => Promise<number[]>.
 */
withCatch(() => Promise.resolve([10]), () => []);
```