### PR TITLE
fix(react-query): drop NoInfer from data source state type

### DIFF
--- a/src/react-query/impl/infinite/types.ts
+++ b/src/react-query/impl/infinite/types.ts
@@ -46,13 +46,13 @@ export type InfiniteQueryDataSource<TParams, TRequest, TResponse, TData, TError>
     >,
     ResultWrapper<
         InfiniteQueryObserverResult<
-            InfiniteData<ActualData<NoInfer<TData>, NoInfer<TResponse>>, Partial<TRequest>>,
-            NoInfer<TError>
+            InfiniteData<ActualData<TData, TResponse>, Partial<TRequest>>,
+            TError
         >,
-        NoInfer<TRequest>,
-        NoInfer<TResponse>,
-        NoInfer<TData>,
-        NoInfer<TError>
+        TRequest,
+        TResponse,
+        TData,
+        TError
     >,
     QueryFunctionContext<DataSourceKey, Partial<NoInfer<TRequest>>>
 > & {

--- a/src/react-query/impl/plain/types.ts
+++ b/src/react-query/impl/plain/types.ts
@@ -38,10 +38,10 @@ export type PlainQueryDataSource<TParams, TRequest, TResponse, TData, TError> = 
         DataSourceKey
     >,
     ResultWrapper<
-        QueryObserverResult<ActualData<NoInfer<TData>, NoInfer<TResponse>>, NoInfer<TError>>,
-        NoInfer<TResponse>,
-        NoInfer<TData>,
-        NoInfer<TError>
+        QueryObserverResult<ActualData<TData, TResponse>, TError>,
+        TResponse,
+        TData,
+        TError
     >,
     QueryFunctionContext<DataSourceKey>
 > & {


### PR DESCRIPTION
## Problem

If a data source's `fetch` returns a discriminated union, consumers cannot narrow
`data` down to a single branch. Any such data source is affected:

```ts
type Payload = {kind: 'empty'} | {kind: 'filled'; items: string[]};

const payloadDataSource = makePlainQueryDataSource({
    name: 'payload',
    fetch: (): Promise<Payload> => fetchPayload(),
});
```

Narrowing by the discriminant then fails in the most common way of writing it:

```ts
const {data} = useQueryData(payloadDataSource, {});
//     ^? NoInfer<Payload> | undefined   — expected Payload | undefined

const filled = data?.kind === 'filled' ? data : undefined;
filled?.items;
// TS2339: Property 'items' does not exist on type 'Payload'.
//   Property 'items' does not exist on type '{ kind: "empty"; }'.
```

This happens regardless of the discriminant's type (string or boolean), and
whether or not the data source declares `transformResponse`.

## Cause

`NoInfer` was applied to the `TState` argument of `PlainQueryDataSource` /
`InfiniteQueryDataSource` — the data position of the state. `NoInfer<T>` is
implemented as a substitution type: transparent for assignability, but **not** a
union type, so discriminant narrowing does not work through it.

This is not an edge-case syntax issue — it breaks the whole "narrow, then store in
a variable" pattern: narrowing is discarded the moment the type is captured (a
`const`/`let` without an annotation, an array literal element, a generic call
argument).

`NoInfer` is not needed in `TState`: it is the phantom field
`[stateHintSymbol]?: TState`, never populated by the user, so nothing is ever
inferred from it.

## Solution

`NoInfer` is removed **only** from the `TState` argument. It is kept in
`TOptions`, `TFetchContext`, `next`/`prev`, `transformParams` and `tags`, where
these are genuine inference positions. The change is type-level only and does not
touch runtime.

After the fix, `data` hovers as `Payload | undefined` and the narrowed `filled`
as `{kind: 'filled'; items: string[]} | undefined`.

Consumers now get narrowed types where narrowing previously failed silently. This
can surface as new compile errors where a narrowed value lands in a mutable slot
and another union branch is written to it later:

    let current = data?.kind === 'filled' ? data : undefined;
    current = {kind: 'empty'}; // now TS2322 — annotate as `Payload | undefined`

Read-only usage is unaffected: a narrower type is assignable everywhere the wider
one was accepted.